### PR TITLE
Removes project specific things, cleanup

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -3,15 +3,15 @@
 if [ "$TRAVIS_BRANCH" == "$MAIN_BRANCH" ]
 then
     echo "Building image with tag latest"
-    docker build -t camptocamp/mapcache:latest .
+    docker build --tag=camptocamp/mapcache:latest .
 elif [ ! -z "$TRAVIS_TAG" ]
 then
     echo "Building image with tag ${TRAVIS_TAG}"
-    docker build -t camptocamp/mapcache:$TRAVIS_TAG .
+    docker build --tag=camptocamp/mapcache:$TRAVIS_TAG .
 elif [ ! -z "$TRAVIS_BRANCH" ]
 then
     echo "Building image with tag ${TRAVIS_BRANCH}"
-    docker build -t camptocamp/mapcache:$TRAVIS_BRANCH .
+    docker build --tag=camptocamp/mapcache:$TRAVIS_BRANCH .
 else
     echo "Don't know how to build image"
     exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -qqy git cmake \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/partial/* /tmp/* /var/tmp/*
 
-RUN mkdir /build && mkdir -p /var/sig/tiles && chown -R www-data /var/sig/tiles
+RUN mkdir /build
 RUN mkdir /mapcache
 
 RUN cd /build && git clone https://github.com/mapserver/mapcache.git && \
@@ -30,7 +30,6 @@ RUN cd /build && git clone https://github.com/mapserver/mapcache.git && \
 
 ADD mapcache.conf /etc/apache2/sites-available/mapcache.conf
 ADD mapcache.load /etc/apache2/mods-available/mapcache.load
-ADD docker-start.sh /
 
 RUN a2enmod mapcache rewrite && \
     a2dissite 000-default && \
@@ -43,8 +42,8 @@ RUN a2enmod mapcache rewrite && \
        ' '{}' ';'
 
 WORKDIR /mapcache
-VOLUME ["/mapcache", "/var/sig/tiles"]
+VOLUME ["/mapcache"]
 
 EXPOSE 80
 
-CMD ["/docker-start.sh"]
+CMD ["apache2ctl", "-DFOREGROUND"]

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-chown -R www-data: /var/sig/tiles
-apache2ctl -DFOREGROUND


### PR DESCRIPTION
Simple alternate of #6 

To test in the ECA project add in the docker-compse file:
```yaml
command: ["/mapcache/start"]
```
And create a file named `mapcache/start` with:
```bash
#!/bin/bash -e

chown -R www-data: /var/sig/tiles
apache2ctl -DFOREGROUND
```
