### PR TITLE
Master fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 MAINTAINER Camptocamp "info@camptocamp.com"
 
 ENV MAPCACHE_VERSION=master \
@@ -16,7 +16,7 @@ RUN apt-get update && \
     apt-get install --assume-yes --no-install-recommends ca-certificates git cmake build-essential \
         liblz-dev libpng-dev libgdal-dev libgeos-dev libpixman-1-dev libsqlite0-dev libcurl4-openssl-dev \
         libaprutil1-dev libapr1-dev libjpeg-dev libdpkg-dev libdb5.3-dev libtiff5-dev libpcre3-dev \
-        apache2 apache2-dev && \
+        apache2 apache2-dev postgresql-server-dev-all && \
     apt-get clean && \
     rm --recursive --force /var/lib/apt/lists/partial/* /tmp/* /var/tmp/* && \
     adduser www-data root && \
@@ -32,7 +32,7 @@ RUN mkdir /build && \
     git checkout ${MAPCACHE_VERSION} && \
     mkdir /build/mapcache/build && \
     cd /build/mapcache/build && \
-    cmake -DCMAKE_BUILD_TYPE=Release -DWITH_MEMCACHE=1 -DWITH_FCGI=0 -DWITH_CGI=0 .. && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DWITH_MEMCACHE=1 -DWITH_FCGI=0 -DWITH_CGI=0 -DWITH_POSTGRESQL=1 .. && \
     make && \
     make install && \
     ldconfig && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,13 @@
-FROM debian:buster
+FROM debian:buster as builder
 MAINTAINER Camptocamp "info@camptocamp.com"
 
-ENV MAPCACHE_VERSION=master \
-    APACHE_CONFDIR=/etc/apache2 \
-    APACHE_RUN_USER=www-data \
-    APACHE_RUN_GROUP=www-data \
-    APACHE_RUN_DIR=/var/run/apache2 \
-    APACHE_PID_FILE=/var/run/apache2/apache2.pid \
-    APACHE_LOCK_DIR=/var/lock/apache2 \
-    APACHE_LOG_DIR=/var/log/apache2 \
-    LANG=C \
-    TERM=linux
+ENV MAPCACHE_VERSION=master
 
 RUN apt-get update && \
     apt-get install --assume-yes --no-install-recommends ca-certificates git cmake build-essential \
         liblz-dev libpng-dev libgdal-dev libgeos-dev libpixman-1-dev libsqlite0-dev libcurl4-openssl-dev \
         libaprutil1-dev libapr1-dev libjpeg-dev libdpkg-dev libdb5.3-dev libtiff5-dev libpcre3-dev \
-        apache2 apache2-dev postgresql-server-dev-all && \
-    apt-get clean && \
-    rm --recursive --force /var/lib/apt/lists/partial/* /tmp/* /var/tmp/* && \
-    adduser www-data root && \
-    mkdir --parent ${APACHE_RUN_DIR} ${APACHE_LOCK_DIR} ${APACHE_LOG_DIR} && \
-    chmod -R g+w /etc/apache2 ${APACHE_RUN_DIR} ${APACHE_LOCK_DIR} ${APACHE_LOG_DIR}
+        apache2 apache2-dev postgresql-server-dev-all
 
 RUN mkdir /build && \
     mkdir /etc/mapcache && \
@@ -38,6 +24,37 @@ RUN mkdir /build && \
     ldconfig && \
     cp /build/mapcache/mapcache.xml /mapcache/ && \
     rm -Rf /build
+
+FROM debian:buster as runner
+LABEL maintainer="info@camptocamp.com"
+
+ENV APACHE_CONFDIR=/etc/apache2 \
+    APACHE_RUN_USER=www-data \
+    APACHE_RUN_GROUP=www-data \
+    APACHE_RUN_DIR=/var/run/apache2 \
+    APACHE_PID_FILE=/var/run/apache2/apache2.pid \
+    APACHE_LOCK_DIR=/var/lock/apache2 \
+    APACHE_LOG_DIR=/var/log/apache2 \
+    LANG=C \
+    TERM=linux
+
+RUN apt-get update && \
+    apt-get install --assume-yes --no-install-recommends ca-certificates \
+        libgdal20 libaprutil1 libapr1 libpixman-1-0 libdb5.3 libpcre3 \
+        apache2 libpq5 && \
+    apt-get clean && \
+    rm --recursive --force /var/lib/apt/lists/partial/* /tmp/* /var/tmp/* && \
+    adduser www-data root && \
+    mkdir --parent ${APACHE_RUN_DIR} ${APACHE_LOCK_DIR} ${APACHE_LOG_DIR} && \
+    chmod -R g+w /etc/apache2 ${APACHE_RUN_DIR} ${APACHE_LOCK_DIR} ${APACHE_LOG_DIR}
+
+COPY --from=builder /usr/local/bin /usr/local/bin/
+COPY --from=builder /usr/local/lib /usr/local/lib/
+COPY --from=builder /usr/lib/apache2/modules/mod_mapcache.so /usr/lib/apache2/modules/mod_mapcache.so
+COPY --from=builder /etc/mapcache/mapcache.xml /etc/mapcache/mapcache.xml
+
+RUN ln --symbolic /etc/mapcache /mapcache
+RUN ldconfig
 
 COPY mapcache.conf /etc/apache2/conf-enabled/
 COPY mapcache.load /etc/apache2/mods-available/

--- a/start-server
+++ b/start-server
@@ -9,4 +9,6 @@ then
     sed -i -e 's/Listen 80$/Listen 8080/' /etc/apache2/ports.conf
 fi
 
-exec apache2ctl -DFOREGROUND
+rm -f $APACHE_RUN_DIR/apache2.pid
+
+exec apache2 -DFOREGROUND


### PR DESCRIPTION
- start-server: run apache2 directly, otherwise Docker SIGSTOP doesn't reach it with 'docker stop'. Also clean existing apache2.pid
- Dockerfile: Add support of Postgresql for dimensions: cherry-picked from other branch
- Dockerfile: split between builder and runner: this reduces the image size from 1.37 GB to 340 MB



